### PR TITLE
修复在一些地区`回到顶部`按钮无法正常显示的BUG

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
  <html>
-<html lang="en">
+<html lang="zh">
 <head>
- <meta charset="UTF-8">
+ <meta charset="UTF-8">
  <title>木晞i的资源汇总</title>
   <link rel="stylesheet" type="text/css" href="styles.css">
  <script>
@@ -44,8 +44,7 @@ a>.btnbacktop{
 
 
   </style>
- <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.4/dist/jquery.min.js"></script>
- <link href="https://cdn.jsdelivr.net/npm/font-awesome@4.7.0/css/font-awesome.min.css" rel="stylesheet">
+ <link href="https://unpkg.com/font-awesome@4.7.0/css/font-awesome.min.css" rel="stylesheet">
 </head>
 
 <body onload="showPopup()">
@@ -59,26 +58,25 @@ a>.btnbacktop{
         </a>
     </div>
  <script>
-$( document ).ready( function(){
-(".backtop").hide();  
-	    $(function () {  
-	        //检测屏幕高度  
-	        var height=$(window).height();  
-	        //scroll() 方法为滚动事件  
-	        $(window).scroll(function(){  
-	            if ($(window).scrollTop()>height){  
-	                $(".backtop").fadeIn(500);  
-	            }else{  
-	                $(".backtop").fadeOut(500);  
-	                }  
-	        });  
-	        $(".backtop").click(function(){  
-	            $('body,html').animate({scrollTop:0},100);  
-	            return false;  
-	        });  
-	    });  
-	});
+const backtop = document.querySelector(".backtop");
+backtop.style.display = "none";
 
+window.onload = function() {
+    const height = window.innerHeight;
+
+    window.onscroll = function() {
+        if (window.pageYOffset > height) {
+            backtop.style.display = "block";
+        } else {
+            backtop.style.display = "none";
+        }
+    };
+
+    backtop.onclick = function() {
+        window.scrollTo({ top: 0, behavior: "smooth" });
+        return false;
+    };
+};
 </script>
 
 <!-- 弹窗 -->


### PR DESCRIPTION
1. 当前的CDN jsdelivr变得很不稳定，在一些地区无法使用。这里将原来的jsdelivr换成了另一个CDN unpkg,目前各地都能正常访问。
2. 一部分用来实现`回到顶部`按钮何时显示的代码，可以不用JQuery直接实现，这样可以少引入一个第三方库。
3. 将一些非ASCII的空格换成了标准空格。

参考
1. [jsDelivr挂了吗-知乎](https://www.zhihu.com/question/533766356) 
2. [jsdelivr各地PING的结果](https://www.itdog.cn/ping/cdn.jsdelivr.net)
4. [unpkg各地PING的结果](https://www.itdog.cn/ping/unpkg.com)

关于这个第三方库的CDN问题其实很让人头疼，这个PR里的修复是比较保守的一些方法。要彻底解决可以考虑将`回到顶部`按钮中的图标换成图片，然后样式自己写一下，这样就不需要任何第三方库了。