### PR TITLE
使用GitHub Action自动检查站点链接是否失效

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -9,7 +9,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check URL
-      run: IFS=$'\n'; for i in `curl -ssL https://yftdtddh.github.io/muxizyhz/ | tr -d '\n' | grep -oP '(<a href="http[s]?://.*?>.*?</a>)'`; do echo $i | grep -oP '(?<=>).*?(?=<)' | xargs echo -n >> report.tsv; echo -e -n "\t"  >> report.tsv; echo $i | grep -oP '(?<=<a href=")(http[s]?://[^"]*)' | xargs echo -n  >> report.tsv; echo -e -n "\t"  >> report.tsv; echo $i | grep -oP '(?<=<a href=")(http[s]?://[^"]*)' | xargs -L 1 curl -I -m 3 -s -w "%{http_code}\n" -o /dev/null  >> report.tsv; done
+      run: |
+        IFS=$'\n';
+        for i in `curl -ssL https://yftdtddh.github.io/muxizyhz/ | tr -d '\n' | grep -oP '(<a href="http[s]?://.*?>.*?</a>)'`; do
+            echo $i | grep -oP '(?<=>).*?(?=<)' | xargs echo -n >> report.tsv;
+            echo -e -n "\t"  >> report.tsv;
+            echo $i | grep -oP '(?<=<a href=")(http[s]?://[^"]*)' | xargs echo -n  >> report.tsv;
+            echo -e -n "\t"  >> report.tsv;
+            echo $i | grep -oP '(?<=<a href=")(http[s]?://[^"]*)' | xargs -L 1 curl -I -m 5 -s -w "%{http_code}\n" -o /dev/null  >> report.tsv;
+        done
     - name: Upload Report
       uses: actions/upload-artifact@v4.0.0
       with:

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,0 +1,16 @@
+name: check-links
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '37 8 * * *'
+
+jobs:
+  check-links:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check URL
+      run: IFS=$'\n'; for i in `curl -ssL https://yftdtddh.github.io/muxizyhz/ | tr -d '\n' | grep -oP '(<a href="http[s]?://.*?>.*?</a>)'`; do echo $i | grep -oP '(?<=>).*?(?=<)' | xargs echo -n >> report.tsv; echo -e -n "\t"  >> report.tsv; echo $i | grep -oP '(?<=<a href=")(http[s]?://[^"]*)' | xargs echo -n  >> report.tsv; echo -e -n "\t"  >> report.tsv; echo $i | grep -oP '(?<=<a href=")(http[s]?://[^"]*)' | xargs -L 1 curl -I -m 3 -s -w "%{http_code}\n" -o /dev/null  >> report.tsv; done
+    - name: Upload Report
+      uses: actions/upload-artifact@v4.0.0
+      with:
+        path: report.tsv

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -9,7 +9,7 @@ jobs:
   check-links:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4.
+    - uses: actions/checkout@v4
     - name: Run URL check script
       uses: adriancoman/link-checks-action@0.1.0
       with:

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -11,4 +11,4 @@ jobs:
     steps:
       - uses: filiph/linkcheck@2.0.23
         with:
-          arguments: https://yftdtddh.github.io/muxizyhz/
+          arguments: -e https://yftdtddh.github.io/muxizyhz/

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -11,6 +11,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Run URL check script
-      uses: adriancoman/link-checks-action@0.1.0
+      uses: adriancoman/link-checks-action@1.0.1
       with:
         file-to-check: "index.html"

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -9,8 +9,6 @@ jobs:
   check-links:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - name: Run URL check script
-      uses: adriancoman/link-checks-action@1.0.1
-      with:
-        file-to-check: "index.html"
+      - uses: filiph/linkcheck@2.0.23
+        with:
+          arguments: https://yftdtddh.github.io/muxizyhz/

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -17,4 +17,5 @@ jobs:
       - uses: actions/upload-artifact@v4.0.0
         if: always()
         with:
+          name: BrokenLinks(坏链).txt
           path: report.txt

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -3,22 +3,14 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '37 8 * * *'
+  push:
 
 jobs:
   check-links:
     runs-on: ubuntu-latest
     steps:
-    - name: Check URL
-      run: |
-        IFS=$'\n';
-        for i in `curl -ssL https://yftdtddh.github.io/muxizyhz/ | tr -d '\n' | grep -oP '(<a href="http[s]?://.*?>.*?</a>)'`; do
-            echo $i | grep -oP '(?<=>).*?(?=<)' | xargs echo -n >> report.tsv;
-            echo -e -n "\t"  >> report.tsv;
-            echo $i | grep -oP '(?<=<a href=")(http[s]?://[^"]*)' | xargs echo -n  >> report.tsv;
-            echo -e -n "\t"  >> report.tsv;
-            echo $i | grep -oP '(?<=<a href=")(http[s]?://[^"]*)' | xargs -L 1 curl -I -m 5 -s -w "%{http_code}\n" -o /dev/null  >> report.tsv;
-        done
-    - name: Upload Report
-      uses: actions/upload-artifact@v4.0.0
+    - uses: actions/checkout@v4.
+    - name: Run URL check script
+      uses: adriancoman/link-checks-action@0.1.0
       with:
-        path: report.tsv
+        file-to-check: "index.html"

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -9,6 +9,6 @@ jobs:
   check-links:
     runs-on: ubuntu-latest
     steps:
-      - uses: filiph/linkcheck@3
+      - uses: filiph/linkcheck@3.0.0
         with:
           arguments: -e https://yftdtddh.github.io/muxizyhz/

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -11,4 +11,7 @@ jobs:
     steps:
       - uses: filiph/linkcheck@3.0.0
         with:
-          arguments: -e https://yftdtddh.github.io/muxizyhz/
+          arguments: -e https://yftdtddh.github.io/muxizyhz/ > report.txt
+      - uses: actions/upload-artifact@v4.0.0
+        with:
+          path: report.txt

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -9,6 +9,6 @@ jobs:
   check-links:
     runs-on: ubuntu-latest
     steps:
-      - uses: filiph/linkcheck@2.0.23
+      - uses: filiph/linkcheck@3
         with:
           arguments: -e https://yftdtddh.github.io/muxizyhz/

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -9,9 +9,12 @@ jobs:
   check-links:
     runs-on: ubuntu-latest
     steps:
+    
       - uses: filiph/linkcheck@3.0.0
         with:
           arguments: -e https://yftdtddh.github.io/muxizyhz/ > report.txt
+      
       - uses: actions/upload-artifact@v4.0.0
+        if: always()
         with:
           path: report.txt


### PR DESCRIPTION
# 功能
使用 GitHub Action 每天自动检查网页里的链接是否失效

- 每天(UTC 8:37) 执行一次
- 每次提交代码后执行一次
- 可以[手动运行](https://docs.github.com/zh/actions/using-workflows/manually-running-a-workflow)

执行一次大约需要十分钟。Action会显示运行失败(只要有一个坏链)，但功能是正常的

# 效果预览
1. 打开: https://github.com/Winterreisender/muxizyhz/actions/runs/7430800019
2. 下载`BrokenLinks(坏链).txt`
3. 解压就可以看到坏掉的链接和坏掉的原因(链接超时、服务器拒绝访问之类的)。

# 使用方法
1. 打开项目的 [Actions](https://github.com/yftdtddh/muxizyhz/actions)
2. 选择 含有`check-links`字样的Action，或者刚刚提交完执行的Action
3. 下载`BrokenLinks(坏链).txt`解压查看

# 其他
- 建议merge时选择合并为一个commit，因为GitHub Action调试比较困难，所以产生了许多不必要的commit
- 建议给GitHub项目加一个开源许可证，这里建议用最严格的AGPL，尽可能保护自己的权利。只需添加一个`LICENSE`文件，把`https://www.gnu.org/licenses/agpl-3.0.txt`的内容复制进去即可。
- 随机壁纸的API挂了，建议换一个。`index.css`里的`https://api.yimian.xyz/img?type=moe&size=1920x1080`换成别的，比如`https://api.paugram.com/wallpaper/`
- 代码是按原样(AS IS)提供的，不提供任何担保